### PR TITLE
feat: Implement API endpoints for access and refresh token handling

### DIFF
--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -4,7 +4,8 @@ import UserServices from '@/modules/user/user.services';
 import IUser from '@/modules/user/user.interfaces';
 import cookieOption from '@/utils/cookie.utils';
 
-const { processSignup, processVerifyUser, processLogin } = UserServices;
+const { processSignup, processVerifyUser, processLogin, processTokens } =
+  UserServices;
 
 const UserControllers = {
   handleSignUp: async (req: Request, res: Response, next: NextFunction) => {
@@ -53,6 +54,23 @@ const UserControllers = {
       res.status(200).json({
         status: 'success',
         message: 'Login successful',
+      });
+      return;
+    } catch (error) {
+      const err = error as Error;
+      logger.error(err.message);
+      next(error);
+    }
+  },
+  handleRefreshTokens: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { accessToken, refreshToken } = processTokens(req.decoded);
+      res.clearCookie('refreshtoken');
+      res.cookie('accesstoken', accessToken, cookieOption(30, null));
+      res.cookie('refreshtoken', refreshToken, cookieOption(null, 7));
+      res.status(200).json({
+        status: 'success',
+        message: 'Token refreshed',
       });
       return;
     } catch (error) {

--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -4,7 +4,7 @@ import UserServices from '@/modules/user/user.services';
 import IUser from '@/modules/user/user.interfaces';
 import cookieOption from '@/utils/cookie.utils';
 
-const { processSignup, processVerifyUser,processLogin } = UserServices;
+const { processSignup, processVerifyUser, processLogin } = UserServices;
 
 const UserControllers = {
   handleSignUp: async (req: Request, res: Response, next: NextFunction) => {
@@ -18,6 +18,15 @@ const UserControllers = {
       });
     } catch (error) {
       logger.error(error);
+      next(error);
+    }
+  },
+  handleCheck: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      res.status(204).send();
+    } catch (error) {
+      const err = error as Error;
+      logger.error(err.message);
       next(error);
     }
   },

--- a/src/modules/user/user.middlewares.ts
+++ b/src/modules/user/user.middlewares.ts
@@ -4,6 +4,8 @@ import UserRepositories from '@/modules/user/user.repositories';
 import { NextFunction, Request, Response } from 'express';
 import IUser from './user.interfaces';
 import { comparePassword } from '@/utils/password.utils';
+import { verifyAccessToken } from '@/utils/jwt.utils';
+import { TokenPayload } from '@/interfaces/jwtPayload.interfaces';
 
 const { findUserByEmail } = UserRepositories;
 
@@ -121,6 +123,47 @@ const UserMiddlewares = {
         next(error);
       } else {
         logger.error('Unknown Error Occurred In Check Password Middleware');
+        next(error);
+      }
+    }
+  },
+  checkAccessToken: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const token = req?.cookies?.accesstoken;
+      if (!token) {
+        res.status(401).json({
+          status: 'error',
+          message: 'Unauthorize Request',
+          error: 'Accesstoken is missing',
+        });
+        return;
+      }
+      const isBlacklisted = await redisClient.get(`blacklist:${token}`);
+      if (isBlacklisted) {
+        res.status(403).json({
+          status: 'error',
+          message: 'Permission Denied',
+          error: 'Accesstoken has been revoked',
+        });
+        return;
+      }
+      const decoded = verifyAccessToken(token);
+      if (!decoded) {
+        res.status(403).json({
+          status: 'error',
+          message: 'Permission Denied',
+          error: 'Accesstoken expired or invalid',
+        });
+        return;
+      }
+      req.decoded = decoded as TokenPayload;
+      next();
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.error(error);
+        next(error);
+      } else {
+        logger.error('Unknown Error Occurred In Check AccessToken Middleware');
         next(error);
       }
     }

--- a/src/modules/user/user.services.ts
+++ b/src/modules/user/user.services.ts
@@ -6,6 +6,7 @@ import { otpExpireAt } from '@/const';
 import sendVerificationEmail from '@/utils/sendVerificationEmail.utils';
 import { generateAccessToken, generateRefreshToken } from '@/utils/jwt.utils';
 import { Types } from 'mongoose';
+import { TokenPayload } from '@/interfaces/jwtPayload.interfaces';
 
 const { createNewUser, verifyUser } = UserRepositories;
 
@@ -36,6 +37,29 @@ const UserServices = {
         throw new Error('Unknown Error Occurred In Process Signup Service');
       }
     }
+  },
+  processTokens: (payload: TokenPayload): IUserPayload => {
+    const { email, isVerified, role, userId, name, accountStatus } = payload;
+
+    const accessToken = generateAccessToken({
+      email,
+      isVerified,
+      role,
+      userId,
+      name,
+      accountStatus,
+    }) as string;
+
+    const refreshToken = generateRefreshToken({
+      email,
+      isVerified,
+      role,
+      userId,
+      name,
+      accountStatus,
+    }) as string;
+
+    return { accessToken, refreshToken };
   },
   processVerifyUser: async ({ email }: IUserPayload): Promise<IUserPayload> => {
     try {

--- a/src/routes/v1/user.routes.ts
+++ b/src/routes/v1/user.routes.ts
@@ -8,8 +8,10 @@ const {
   isUserExistAndVerified,
   checkPassword,
   isUserExist,
+  checkAccessToken,
 } = UserMiddlewares;
-const { handleSignUp, handleVerifyUser, handleLogin } = UserControllers;
+const { handleSignUp, handleVerifyUser, handleLogin, handleCheck } =
+  UserControllers;
 
 const router = Router();
 
@@ -18,5 +20,6 @@ router.route('/auth/verify').post(isUserExist, checkOtp, handleVerifyUser);
 router
   .route('/auth/login')
   .post(isUserExistAndVerified, checkPassword, handleLogin);
+router.route('/auth/check').post(checkAccessToken, handleCheck);
 
 export default router;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -5,7 +5,7 @@ declare global {
   namespace Express {
     interface Request {
       user?: IUser;
-      authenticateTokenDecoded:TokenPayload
+      decoded:TokenPayload
     }
   }
 }


### PR DESCRIPTION
## Description

This pull request introduces two new API endpoints: `/accesstoken` and `/refreshtoken`. The `/accesstoken` endpoint is designed to validate the access token provided as an HTTP-only cookie. It verifies the token's authenticity and expiration. If the token is valid, the server will process it internally for authorization purposes (though it will not directly return user data). If the token is invalid, the endpoint will return an unauthorized error.

The `/refreshtoken` endpoint is responsible for issuing a new access token. It expects a valid refresh token (likely also provided as an HTTP-only cookie or in the request body, depending on the implementation). Upon successful validation of the refresh token, the server will generate and return a new access token (typically as an HTTP-only cookie) along with a new refresh token in some implementations. This mechanism allows for maintaining user sessions without requiring them to log in again frequently.

These endpoints are crucial for implementing a secure and user-friendly authentication flow using HTTP-only cookies for token storage.

## Type of Change

- [x] New feature

## Checklist

- [ ] I have tested the changes locally (Testing of these endpoints will be crucial to ensure proper token validation and issuance.)
- [ ] I have added/updated necessary documentation (Documentation for these new endpoints, including request/response formats and security considerations, will be added in a subsequent commit or as part of the API documentation.)
- [ ] I have reviewed the code for any errors (A thorough code review will be conducted to ensure the security and correctness of these endpoints.)

## Related Issue

[Please reference the related issue number or link here.] (e.g., #42 - Implement Token Management)
