### PR TITLE
feature: resend otp email endpoint implemented

### DIFF
--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -10,6 +10,7 @@ const {
   processLogin,
   processTokens,
   processLogout,
+  processResend,
 } = UserServices;
 
 const UserControllers = {
@@ -45,6 +46,19 @@ const UserControllers = {
       res.status(200).json({
         success: true,
         message: 'Email verification successful',
+      });
+    } catch (error) {
+      logger.error(error);
+      next(error);
+    }
+  },
+  handleResend: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const user = req?.user as IUser;
+      await processResend(user);
+      res.status(200).json({
+        success: true,
+        message: 'Verification Email Resend Successful',
       });
     } catch (error) {
       logger.error(error);

--- a/src/routes/v1/user.routes.ts
+++ b/src/routes/v1/user.routes.ts
@@ -18,12 +18,14 @@ const {
   handleCheck,
   handleRefreshTokens,
   handleLogout,
+  handleResend,
 } = UserControllers;
 
 const router = Router();
 
 router.route('/auth/signup').post(isSignupUserExist, handleSignUp);
 router.route('/auth/verify').post(isUserExist, checkOtp, handleVerifyUser);
+router.route('/auth/resend').post(isUserExist, handleResend);
 router
   .route('/auth/login')
   .post(isUserExistAndVerified, checkPassword, handleLogin);


### PR DESCRIPTION
# feature: resend otp email endpoint implemented

## Description

This commit introduces a new endpoint that allows users to resend OTP emails during the verification process. This is useful in cases where the user did not receive the original OTP or it expired.

## Type of Change

Please select the type of change that applies:

- [ ] Bug fix  
- [x] New feature  
- [ ] Refactor  
- [ ] Documentation update  

## Checklist

- [x] I have tested the changes locally  
- [x] I have added/updated necessary documentation  
- [x] I have reviewed the code for any errors  

## Related Issue

Issue: N/A

## Additional Notes

- No rate limiting has been implemented yet—consider adding cooldown logic in a future update to prevent abuse.
- Endpoint adds flexibility to the email verification flow.
