### PR TITLE
fix(production): in cookie option remove the domain and make domain optional in CookieOptions Interface

### DIFF
--- a/src/interfaces/cookie.interface.ts
+++ b/src/interfaces/cookie.interface.ts
@@ -3,6 +3,6 @@ export default interface CookieOptions {
   secure: boolean;
   sameSite: 'none' | 'lax' | 'strict';
   path: string;
-  domain: string;
+  domain?: string;
   maxAge?: number;
 }

--- a/src/utils/cookie.utils.ts
+++ b/src/utils/cookie.utils.ts
@@ -10,8 +10,6 @@ const cookieOption = (
     secure: env.NODE_ENV === 'production',
     sameSite: env.NODE_ENV === 'production' ? 'none' : 'lax',
     path: '/',
-    domain:
-      env.NODE_ENV === 'production' ? 'amar-contacts.vercel.app' : 'localhost',
   };
 
   if (min) {


### PR DESCRIPTION
# fix(production): in cookie option remove the domain and make domain optional in CookieOptions Interface

## Description

This PR removes the hardcoded `domain` property from the cookie options used in production, which was preventing cookies from being set properly in cross-site environments (e.g., frontend on Vercel and backend on Render). The browser was rejecting cookies due to a mismatch between the `domain` value (`amar-contacts.vercel.app`) and the origin that was trying to set it (`amar-contacts-server.onrender.com`).

To resolve this, the `domain` field was removed from the default cookie config, allowing the browser to set it automatically based on the backend domain. Additionally, the `domain` field in the `CookieOptions` interface was made optional to reflect this change and improve type safety.

## Type of Change

Please select the type of change that applies:

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Checklist

- [x] I have tested the changes locally
- [ ] I have added/updated necessary documentation
- [x] I have reviewed the code for any errors

## Related Issue

N/A

## Additional Notes

This fix ensures compatibility with cross-origin deployments while maintaining secure cookie practices using `sameSite: 'none'` and `secure: true`. It unblocks login functionality in production environments.
