### PR TITLE
fix(recover): password hashing issue resolved

### DIFF
--- a/src/modules/user/user.middlewares.ts
+++ b/src/modules/user/user.middlewares.ts
@@ -313,20 +313,6 @@ const UserMiddlewares = {
       }
     }
   },
-  handleVerifyOtp: (req: Request, res: Response, next: NextFunction) => {
-    try {
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.error(error);
-        next(error);
-      } else {
-        logger.error(
-          'Unknown Error Occurred In Check Recover Token Middleware'
-        );
-        next(error);
-      }
-    }
-  },
   getRealIP: (req: Request) => {
     return (
       req.headers['x-forwarded-for'] ||

--- a/src/modules/user/user.services.ts
+++ b/src/modules/user/user.services.ts
@@ -19,6 +19,7 @@ import JwtUtils from '@/utils/jwt.utils';
 import { Types } from 'mongoose';
 import { IRefreshTokenPayload } from '@/interfaces/jwtPayload.interfaces';
 import CalculationUtils from '@/utils/calculation.utils';
+import { hashPassword } from '@/utils/password.utils';
 
 const {
   sendAccountVerificationOtpEmail,
@@ -354,6 +355,7 @@ const UserServices = {
     isVerified,
   }: IResetPasswordServicePayload): Promise<IResetPasswordServiceReturnPayload> => {
     try {
+      const hashed = (await hashPassword(password)) as string;
       const newAccessToken = generateAccessToken({
         email,
         isVerified,
@@ -368,7 +370,7 @@ const UserServices = {
         name,
       }) as string;
       await Promise.all([
-        resetPassword({ userId, password }),
+        resetPassword({ userId, password: hashed }),
         redisClient.set(
           `blacklist:recover:r_stp2:${userId}`,
           r_stp3,


### PR DESCRIPTION
## Description

This PR addresses an issue in the password recovery flow where the new password was not being properly hashed before being saved to the database. This resulted in users being unable to log in with their newly set password after completing the recovery process.

### Fix Summary:
- Ensured proper password hashing using the existing hashing utility before updating the user's password.
- Added a safeguard to prevent saving plain-text passwords in recovery logic.

## Type of Change

Please select the type of change that applies:

- [x] Bug fix  
- [ ] New feature  
- [ ] Refactor  
- [ ] Documentation update  

## Checklist

- [x] I have tested the changes locally  
- [ ] I have added/updated necessary documentation
- [x] I have reviewed the code for any errors  

## Related Issue

N/A

## Additional Notes

- No changes to the frontend or API contract were required.  
- This bug was reported internally during QA testing of the password recovery feature.  
- Consider adding unit tests for password recovery logic in future iterations.