### PR TITLE
feature: get proifle endpoint implemented

### DIFF
--- a/src/modules/profile/profile.controllers.ts
+++ b/src/modules/profile/profile.controllers.ts
@@ -39,10 +39,20 @@ const ProfileControllers = {
   handleGetProfile: async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { userId } = req.decoded;
-      const data = await processGetProfile({ user: userId });
-      res
-        .status(200)
-        .json({ status: 'success', message: 'get profile successful', data });
+      const queryString = req.query.fields as string;
+      if (queryString && queryString?.length > 0) {
+        const queryFieldList = queryString.split(',');
+        const { userId } = req.decoded;
+        const data = await processGetProfile({ user: userId, queryFieldList });
+        res
+          .status(200)
+          .json({ status: 'success', message: 'get profile successful', data });
+      } else {
+        const data = await processGetProfile({ user: userId });
+        res
+          .status(200)
+          .json({ status: 'success', message: 'get profile successful', data });
+      }
       return;
     } catch (error) {
       const err = error as Error;

--- a/src/modules/profile/profile.interfaces.ts
+++ b/src/modules/profile/profile.interfaces.ts
@@ -29,10 +29,42 @@ export interface IProfilePayload {
   dateOfBirth?: string;
   user?: Types.ObjectId;
   profileId?: Types.ObjectId;
+  queryFieldList?: string[];
   name?: string;
   phone?: string;
   avatar?: IImage;
   password?: TPassword;
+  gender?: TGender;
+}
+export interface IProfileProjection {
+  location?: string;
+  dateOfBirth?: string;
+  user?: number;
+  name?: number;
+  phone?: number;
+  avatar?: number;
+  gender?: string;
+  _id: number;
+  email?: number;
+}
+
+export type TProfileProjection = {
+  location?: number;
+  dateOfBirth?: number;
+  email?: number;
+  user?: number;
+  name?: number;
+  phone?: number;
+  avatar?: number;
+  gender?: number;
+};
+
+export type TQuery = {};
+
+export interface IGetProfilePayload {
+  user?: Types.ObjectId;
+  query?: IProfileProjection;
+  queryFieldList?: string[];
 }
 
 export interface IGetProfileData {
@@ -41,6 +73,9 @@ export interface IGetProfileData {
   email?: string;
   avatar?: IImage;
   phone?: string;
+  location?: TLocation;
+  dateOfBirth?: string;
+  gender?: TGender;
 }
 
 export default IProfile;

--- a/src/modules/profile/profile.services.ts
+++ b/src/modules/profile/profile.services.ts
@@ -1,6 +1,11 @@
 import redisClient from '@/configs/redis.configs';
 import { serverCacheExpiredIn } from '@/const';
-import { IProfilePayload } from '@/modules/profile/profile.interfaces';
+import {
+  IGetProfilePayload,
+  IProfilePayload,
+  IProfileProjection,
+  TProfileProjection,
+} from '@/modules/profile/profile.interfaces';
 import ProfileRepositories from '@/modules/profile/profile.repositories';
 import { TPassword } from '@/modules/user/user.interfaces';
 import CalculationUtils from '@/utils/calculation.utils';
@@ -25,20 +30,30 @@ const ProfileServices = {
       }
     }
   },
-  processGetProfile: async (payload: IProfilePayload) => {
+  processGetProfile: async ({ queryFieldList, user }: IGetProfilePayload) => {
     try {
-      const cacheData = await redisClient.get(`me:${payload.user}`);
-      if (!cacheData) {
-        const data = await getProfile(payload);
-        await redisClient.set(
-          `me:${payload.user}`,
-          JSON.stringify(data),
-          'PX',
-          expiresInTimeUnitToMs(serverCacheExpiredIn)
-        );
-        return data;
+      if (queryFieldList && queryFieldList.length > 0) {
+        const projection: IProfileProjection = { _id: 0 };
+        queryFieldList.forEach((fieldName) => {
+          if (fieldName === 'location') {
+            projection.location = '$profile.location';
+          } else if (fieldName === 'dateOfBirth') {
+            projection.dateOfBirth = '$profile.dateOfBirth';
+          } else if (fieldName === 'gender') {
+            projection.dateOfBirth = '$profile.gender';
+          } else if (fieldName === 'name') {
+            projection.name = 1;
+          } else if (fieldName === 'avatar') {
+            projection.avatar = 1;
+          } else if (fieldName === 'email') {
+            projection.email = 1;
+          } else if (fieldName === 'phone') {
+            projection.phone = 1;
+          }
+        });
+        return await getProfile({ user, query:projection });
       } else {
-        return JSON.parse(cacheData);
+        return await getProfile({ user });
       }
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
## Description

Implemented the `GET /me` endpoint to retrieve authenticated user profile data.  
This includes aggregated data from both `User` and associated `Profile` collections using `$lookup` and `$project` in MongoDB aggregation pipeline.  
The endpoint also supports dynamic field selection via the `fields` query parameter (e.g., `?fields=name,email,location`) to optimize frontend data consumption.

## Type of Change

Please select the type of change that applies:

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update

## Checklist

- [x] I have tested the changes locally
- [x] I have added/updated necessary documentation
- [x] I have reviewed the code for any errors

## Related Issue

None

## Additional Notes

- Nullable fields are handled gracefully in the projection using `$ifNull` where necessary.
- Ensured the shape of the response remains consistent even when profile data is missing.
- This endpoint will be used in the account center/profile settings page of the frontend.
